### PR TITLE
fix: Clean up index.md and set site URL in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,9 @@ email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
   This is my awesome new blog, powered by Jekyll and GitHub Pages.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
+url: "https://ray-sh.github.io" # the base hostname & protocol for your site
+twitter_username: jekyllrb # Replace with your twitter username
+github_username:  ray-sh # Replace with your github username
 
 # Build settings
 markdown: kramdown

--- a/index.md
+++ b/index.md
@@ -1,10 +1,8 @@
 ---
- layout: home
- title: Home
- ---
+layout: home
+title: Home
+---
 
+# Welcome to My Awesome Blog!
 
-
- # Welcome to My Awesome Blog!
-
- This is the homepage of my new blog. Stay tuned for exciting content!
+This is the homepage of my new blog. Stay tuned for exciting content!


### PR DESCRIPTION
- Overwrote index.md to ensure no invisible characters or front matter issues.
- Set the `url` in `_config.yml` to `https://ray-sh.github.io` for proper absolute URL generation by Jekyll plugins.
- Updated `github_username` in `_config.yml` to `ray-sh`.

These changes aim to resolve homepage formatting issues and ensure correct site metadata.